### PR TITLE
Include base pools added to a registry before registry is indexed on the address provider

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,7 +20,13 @@
     "deploy:fantom": "yarn workspaces run deploy:fantom",
     "deploy:arbitrum": "yarn workspaces run deploy:arbitrum",
     "deploy:matic": "yarn workspaces run deploy:matic",
-    "deploy:xdai": "yarn workspaces run deploy:xdai"
+    "deploy:xdai": "yarn workspaces run deploy:xdai",
+    "stage:mainnet": "yarn workspaces run stage:mainnet",
+    "stage:avalanche": "yarn workspaces run stage:avalanche",
+    "stage:fantom": "yarn workspaces run stage:fantom",
+    "stage:arbitrum": "yarn workspaces run stage:arbitrum",
+    "stage:matic": "yarn workspaces run stage:matic",
+    "stage:xdai": "yarn workspaces run stage:xdai"
   },
   "devDependencies": {
     "@graphprotocol/graph-cli": "0.22.1",

--- a/packages/constants/package.json
+++ b/packages/constants/package.json
@@ -19,6 +19,12 @@
     "deploy:fantom": "true",
     "deploy:arbitrum": "true",
     "deploy:matic": "true",
-    "deploy:xdai": "true"
+    "deploy:xdai": "true",
+    "stage:mainnet": "true",
+    "stage:avalanche": "true",
+    "stage:fantom": "true",
+    "stage:arbitrum": "true",
+    "stage:matic": "true",
+    "stage:xdai": "true"
   }
 }

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -19,6 +19,12 @@
     "deploy:fantom": "true",
     "deploy:arbitrum": "true",
     "deploy:matic": "true",
-    "deploy:xdai": "true"
+    "deploy:xdai": "true",
+    "stage:mainnet": "true",
+    "stage:avalanche": "true",
+    "stage:fantom": "true",
+    "stage:arbitrum": "true",
+    "stage:matic": "true",
+    "stage:xdai": "true"
   }
 }

--- a/subgraphs/volume/abis/CurvePoolCoin128.json
+++ b/subgraphs/volume/abis/CurvePoolCoin128.json
@@ -17,5 +17,24 @@
     "payable": false,
     "type": "function",
     "gas": 2310
+  },
+  {
+    "name":"balances",
+    "outputs":[
+      {
+        "type":"uint256",
+        "name":""
+      }
+    ],
+    "inputs":[
+      {
+        "type":"int128",
+        "name":"arg0"
+      }
+    ],
+    "constant":true,
+    "payable":false,
+    "type":"function",
+    "gas":2340
   }
 ]

--- a/subgraphs/volume/package.json
+++ b/subgraphs/volume/package.json
@@ -16,7 +16,13 @@
     "deploy:fantom": "graph deploy --node https://api.thegraph.com/deploy/ convex-community/volume-fantom",
     "deploy:arbitrum": "graph deploy --node https://api.thegraph.com/deploy/ convex-community/volume-arbitrum",
     "deploy:matic": "graph deploy --node https://api.thegraph.com/deploy/ convex-community/volume-matic",
-    "deploy:xdai": "graph deploy --node https://api.thegraph.com/deploy/ convex-community/volume-xdai"
+    "deploy:xdai": "graph deploy --node https://api.thegraph.com/deploy/ convex-community/volume-xdai",
+    "stage:mainnet": "graph deploy --node https://api.thegraph.com/deploy/ convex-community/volume-mainnet-staging",
+    "stage:avalanche": "graph deploy --node https://api.thegraph.com/deploy/ convex-community/volume-avalanche-staging",
+    "stage:fantom": "graph deploy --node https://api.thegraph.com/deploy/ convex-community/volume-fantom-staging",
+    "stage:arbitrum": "graph deploy --node https://api.thegraph.com/deploy/ convex-community/volume-arbitrum-staging",
+    "stage:matic": "graph deploy --node https://api.thegraph.com/deploy/ convex-community/volume-matic-staging",
+    "stage:xdai": "graph deploy --node https://api.thegraph.com/deploy/ convex-community/volume-xdai-staging"
   },
   "dependencies": {
     "@graphprotocol/graph-cli": "0.22.3",


### PR DESCRIPTION
Pools that are added to a Registry before the registry is added to the Address Indexer can not be tracked by the subgraph. The mainnet 3pool is in that situation. This is a workaround to ensure that the subgraph tracks the 3pool (and other improperly indexed base pools) as well.

A fully-synced version of the subgraph including this fix is deployed at: https://thegraph.com/hosted-service/subgraph/convex-community/volume-mainnet-staging 

**Details:** 

Because the latest version of the subgraph is dependent on the address provider to track new registries, factories and the pools they index. This means that if a pool is added to a registry (including factory deployment) before the registry is indexed on the address provider contract, the subgraph will not be able to track that pool.

The 3pool is a case in point, it was [added to the stable registry](https://etherscan.io/tx/0x71e1f0182953765d3579968c012ef1957e61bdebd92d51e6c837a2c0d736cce8) on April 7th, 2021. But the stable registry was only [indexed on the address provider a day later](https://etherscan.io/tx/0x1b9f1446e4c7f55079aabf81a113d04d46f04992ef6d1f6347d54b7ce1529302) on April 8th, 2021.

Because the subgraph relies on information broadcasted by the events (or via the function call's params) when a pool is added to a registry in order to categorize the pools and assign them the appropriate ABI, it's impossible to work backwards (i.e. scan for and add all the already indexed pools on a registry retroactively when the registry is added to the address provider for the first time). 

Base pools are an exception since information from their metapools can be used to categorize them. This allows the subgraph to track the 3pool and some other base pools that weren't tracked before.