### PR TITLE
Check for multiple rebasing pool implementations

### DIFF
--- a/config/arbitrum.json
+++ b/config/arbitrum.json
@@ -32,6 +32,6 @@
   "aethMapping": "",
   "importChainRebaseAprModule": "",
   "returnChainRebaseApr": "return BIG_DECIMAL_ZERO",
-  "rebasingPoolImplementation": "0x55aa9bf126bcabf0bdc17fa9e39ec9239e1ce7a9",
+  "rebasingPoolImplementations": "['0x55aa9bf126bcabf0bdc17fa9e39ec9239e1ce7a9']",
   "tvlThreshold": "10000000000"
 }

--- a/config/avalanche.json
+++ b/config/avalanche.json
@@ -32,6 +32,6 @@
   "aethMapping": "",
   "importChainRebaseAprModule": "import { getAvalanchePoolApr } from './avalanche'",
   "returnChainRebaseApr": "return getAvalanchePoolApr(pool, reserves, timestamp, tvl)",
-  "rebasingPoolImplementation": "0x55aa9bf126bcabf0bdc17fa9e39ec9239e1ce7a9",
+  "rebasingPoolImplementations": "['0x55aa9bf126bcabf0bdc17fa9e39ec9239e1ce7a9']",
   "tvlThreshold": "1000000000"
 }

--- a/config/fantom.json
+++ b/config/fantom.json
@@ -32,6 +32,6 @@
   "aethMapping": "",
   "importChainRebaseAprModule": "import { getFantomPoolApr } from './fantom'",
   "returnChainRebaseApr": "return getFantomPoolApr(pool, reserves, timestamp, tvl)",
-  "rebasingPoolImplementation": "0x55aa9bf126bcabf0bdc17fa9e39ec9239e1ce7a9",
+  "rebasingPoolImplementations": "['0x55aa9bf126bcabf0bdc17fa9e39ec9239e1ce7a9']",
   "tvlThreshold": "1000000000"
 }

--- a/config/harmony.json
+++ b/config/harmony.json
@@ -32,6 +32,6 @@
   "aethMapping": "",
   "importChainRebaseAprModule": "",
   "returnChainRebaseApr": "return BIG_DECIMAL_ZERO",
-  "rebasingPoolImplementation": "0x55aa9bf126bcabf0bdc17fa9e39ec9239e1ce7a9",
+  "rebasingPoolImplementations": "['0x55aa9bf126bcabf0bdc17fa9e39ec9239e1ce7a9']",
   "tvlThreshold": "1000000000"
 }

--- a/config/mainnet.json
+++ b/config/mainnet.json
@@ -32,6 +32,6 @@
   "aethMapping": "  - kind: ethereum/contract\n    name: AETH\n    network: mainnet\n    source:\n      address: \"0x6a9366f02B6E252e0cbe2E6B9CF0a8adDd7B641C\"\n      startBlock: 10970706\n      abi: AETH\n    mapping:\n      kind: ethereum/events\n      apiVersion: 0.0.7\n      language: wasm/assemblyscript\n      entities:\n        - TokenSnapshot\n      abis:\n        - name: AETH\n          file: ./abis/AETH.json\n      eventHandlers:\n        - event: RatioUpdate(uint256)\n          handler: handleAethRewards\n      file: ./src/services/rebase/mappingAeth.ts",
   "importChainRebaseAprModule": "import { getMainnetPoolApr } from './mainnet'",
   "returnChainRebaseApr": "return getMainnetPoolApr(pool, reserves, timestamp, tvl)",
-  "rebasingPoolImplementation": "0x55aa9bf126bcabf0bdc17fa9e39ec9239e1ce7a9",
+  "rebasingPoolImplementations": "['0x55aa9bf126bcabf0bdc17fa9e39ec9239e1ce7a9']",
   "tvlThreshold": "50000000000"
 }

--- a/config/matic.json
+++ b/config/matic.json
@@ -32,6 +32,6 @@
   "aethMapping": "",
   "importChainRebaseAprModule": "import { getMaticPoolApr } from './matic'",
   "returnChainRebaseApr": "return getMaticPoolApr(pool, reserves, timestamp, tvl)",
-  "rebasingPoolImplementation": "0xc7c46488566b9ef9b981b87e328939caa5ca152f",
+  "rebasingPoolImplementations": "['0xc7c46488566b9ef9b981b87e328939caa5ca152f', '0x39fe1824f98cd828050d7c51da443e84121c7cf1']",
   "tvlThreshold": "1000000000"
 }

--- a/config/moonbeam.json
+++ b/config/moonbeam.json
@@ -32,6 +32,6 @@
   "aethMapping": "",
   "importChainRebaseAprModule": "",
   "returnChainRebaseApr": "return BIG_DECIMAL_ZERO",
-  "rebasingPoolImplementation": "0x55aa9bf126bcabf0bdc17fa9e39ec9239e1ce7a9",
+  "rebasingPoolImplementations": "['0x55aa9bf126bcabf0bdc17fa9e39ec9239e1ce7a9']",
   "tvlThreshold": "1000000000"
 }

--- a/config/optimism.json
+++ b/config/optimism.json
@@ -32,6 +32,6 @@
   "aethMapping": "",
   "importChainRebaseAprModule": "",
   "returnChainRebaseApr": "return BIG_DECIMAL_ZERO",
-  "rebasingPoolImplementation": "0x55aa9bf126bcabf0bdc17fa9e39ec9239e1ce7a9",
+  "rebasingPoolImplementations": "['0x55aa9bf126bcabf0bdc17fa9e39ec9239e1ce7a9']",
   "tvlThreshold": "1000000000"
 }

--- a/config/xdai.json
+++ b/config/xdai.json
@@ -32,6 +32,6 @@
   "aethMapping": "",
   "importChainRebaseAprModule": "",
   "returnChainRebaseApr": "return BIG_DECIMAL_ZERO",
-  "rebasingPoolImplementation": "0x55aa9bf126bcabf0bdc17fa9e39ec9239e1ce7a9",
+  "rebasingPoolImplementations": "['0x55aa9bf126bcabf0bdc17fa9e39ec9239e1ce7a9']",
   "tvlThreshold": "1000000000"
 }

--- a/packages/constants/index.template.ts
+++ b/packages/constants/index.template.ts
@@ -346,8 +346,8 @@ export const CTOKEN_POOLS = ["0xa2b47e3d5c44877cca798226b7b8118f9bfb7a56",
 // Factory metapools that use the implementation for positive-rebasing and
 // and fee-on-transfer tokens do not log decimals the same way as regular
 // factory metapools.
-export const REBASING_POOL_IMPLEMENTATION = '{{ rebasingPoolImplementation }}'
-export const REBASING_POOL_IMPLEMENTATION_ADDRESS = Address.fromString(REBASING_POOL_IMPLEMENTATION)
+export const REBASING_POOL_IMPLEMENTATIONS: Array<string> = {{{rebasingPoolImplementations}}}
+export const REBASING_POOL_IMPLEMENTATION_ADDRESSES = REBASING_POOL_IMPLEMENTATIONS.map<Address>(function(x: string) { return Address.fromString(x)})
 
 // Addresses and variables needed to compute the APR of rebasing tokens
 export const LIDO_ORACLE_ADDRESS = Address.fromString("0x442af784A788A5bd6F42A01Ebe9F287a871243fb")

--- a/subgraphs/volume/src/services/pools.ts
+++ b/subgraphs/volume/src/services/pools.ts
@@ -11,7 +11,7 @@ import {
   CRYPTO_FACTORY,
   METAPOOL_FACTORY,
   METAPOOL_FACTORY_ADDRESS,
-  REBASING_POOL_IMPLEMENTATION_ADDRESS,
+  REBASING_POOL_IMPLEMENTATION_ADDRESSES,
   STABLE_FACTORY,
 } from '../../../../packages/constants'
 import { CurvePoolTemplate, CurvePoolTemplateV2 } from '../../generated/templates'
@@ -136,7 +136,7 @@ export function createNewFactoryPool(
     factoryPool = factory.pool_list(poolCount)
     const implementationResult = factory.try_get_implementation_address(factoryPool)
     if (!implementationResult.reverted) {
-      isRebasing = implementationResult.value == REBASING_POOL_IMPLEMENTATION_ADDRESS
+      isRebasing = REBASING_POOL_IMPLEMENTATION_ADDRESSES.includes(implementationResult.value)
     }
     log.info('New factory pool (metapool: {}, base pool: {}) added {} with id {}', [
       metapool.toString(),


### PR DESCRIPTION
Subgraph only considered the possibility of a single implementation having inconsistent decimals for logging, but there are actually several.
This let's check a pool's implementation against several addresses instead of just one.