### PR TITLE
Store additional properties on pool & snapshot entities

### DIFF
--- a/packages/utils/index.ts
+++ b/packages/utils/index.ts
@@ -1,4 +1,4 @@
-import { Address, Bytes } from '@graphprotocol/graph-ts'
+import { Address, BigDecimal, BigInt, Bytes } from '@graphprotocol/graph-ts'
 import { ADDRESS_ZERO } from 'const'
 
 export function bytesToAddress(input: Bytes): Address {
@@ -6,4 +6,8 @@ export function bytesToAddress(input: Bytes): Address {
   if (inputAsStr.length != 42) {
     return ADDRESS_ZERO
   } else return Address.fromString(inputAsStr)
+}
+
+export function BigDecimalToBigInt(input: BigDecimal): BigInt {
+  return BigInt.fromString(input.truncate(0).toString())
 }

--- a/subgraphs/volume/schema.graphql
+++ b/subgraphs/volume/schema.graphql
@@ -37,6 +37,7 @@ type Pool @entity {
   coinNames: [String!]!
   assetType: Int!
   poolType: PoolType!
+  c128: Boolean! # whether the pool uses int128 for coins
   isV2: Boolean!
   isRebasing: Boolean!
   cumulativeVolume: BigDecimal!

--- a/subgraphs/volume/schema.graphql
+++ b/subgraphs/volume/schema.graphql
@@ -94,6 +94,7 @@ type DailyPoolSnapshot @entity {
   lpPriceUSD: BigDecimal!
   tvl: BigDecimal!
   fee: BigDecimal!
+  offPegFeeMultiplier: BigDecimal!
   adminFee: BigDecimal!
   adminFeesUSD: BigDecimal!
   lpFeesUSD: BigDecimal!
@@ -102,6 +103,7 @@ type DailyPoolSnapshot @entity {
   reserves: [BigInt!]!
   normalizedReserves: [BigInt!]!
   reservesUSD: [BigDecimal!]!
+  A: BigInt!
   xcpProfit: BigDecimal!
   xcpProfitA: BigDecimal!
   baseApr: BigDecimal!

--- a/subgraphs/volume/schema.graphql
+++ b/subgraphs/volume/schema.graphql
@@ -100,6 +100,7 @@ type DailyPoolSnapshot @entity {
   eventFeesUSD: BigDecimal!
   totalDailyFeesUSD: BigDecimal!
   reserves: [BigInt!]!
+  normalizedReserves: [BigInt!]!
   reservesUSD: [BigDecimal!]!
   xcpProfit: BigDecimal!
   xcpProfitA: BigDecimal!

--- a/subgraphs/volume/src/mapping.template.ts
+++ b/subgraphs/volume/src/mapping.template.ts
@@ -40,6 +40,7 @@ import {
   processAddLiquidity,
   processLiquidityRemoval
 } from './services/liquidity'
+import { getOffPegFeeMultiplierResult } from './services/snapshots'
 {{{ importExistingMetaPools }}}
 
 
@@ -116,7 +117,7 @@ export function addRegistryPool(pool: Address,
   const testLending = CurveLendingPool.bind(pool)
   // The test would not work on mainnet because there are no
   // specific functions for lending pools there.
-  const testLendingResult = testLending.try_offpeg_fee_multiplier()
+  const testLendingResult = getOffPegFeeMultiplierResult(pool)
   if (!testLendingResult.reverted || LENDING_POOLS.includes(pool)) {
     // Lending pool
     log.info('New lending pool {} added from registry at {}', [

--- a/subgraphs/volume/src/services/pools.ts
+++ b/subgraphs/volume/src/services/pools.ts
@@ -100,6 +100,7 @@ export function createNewPool(
     pool.coins = coins
     pool.coinNames = coinNames
     pool.coinDecimals = coinDecimals
+    pool.assetType = isV2 ? 4 : getAssetType(pool.name, pool.symbol, pool.coinNames)
     pool.save()
     return
   }

--- a/subgraphs/volume/src/services/pools.ts
+++ b/subgraphs/volume/src/services/pools.ts
@@ -59,6 +59,7 @@ export function createNewPool(
   pool.creationTx = tx
   pool.creationDate = timestamp
   pool.poolType = poolType
+  pool.c128 = false
   pool.basePool = basePool
   pool.cumulativeVolume = BIG_DECIMAL_ZERO
   pool.cumulativeVolumeUSD = BIG_DECIMAL_ZERO
@@ -81,11 +82,13 @@ export function createNewPool(
     log.debug('Call to coins reverted for pool ({}), attempting 128 bytes call', [pool.id])
     const poolContract = CurvePoolCoin128.bind(poolAddress)
     const coins = pool.coins
+    pool.c128 = true
     const coinNames = pool.coinNames
     const coinDecimals = pool.coinDecimals
     let coinResult = poolContract.try_coins(BigInt.fromI32(i))
     if (coinResult.reverted) {
       log.warning('Call to int128 coins failed for {}', [pool.id])
+      pool.c128 = false
     }
     while (!coinResult.reverted) {
       coins.push(coinResult.value)

--- a/subgraphs/volume/subgraph.template.yaml
+++ b/subgraphs/volume/subgraph.template.yaml
@@ -129,6 +129,8 @@ templates:
           file: ./abis/LidoOracle.json
         - name: MetaPool
           file: ./abis/MetaPool.json
+        - name: CurveLendingPool
+          file: ./abis/CurveLendingPool.json
         - name: CurvePoolCoin128
           file: ./abis/CurvePoolCoin128.json
         - name: CurvePoolV2
@@ -168,6 +170,8 @@ templates:
           file: ./abis/CurvePool.json
         - name: MetaPool
           file: ./abis/MetaPool.json
+        - name: CurveLendingPool
+          file: ./abis/CurveLendingPool.json
         - name: CurvePoolV2
           file: ./abis/CurvePoolV2.json
         - name: ERC20
@@ -233,6 +237,8 @@ templates:
           file: ./abis/CLAggregator.json
         - name: CurvePoolCoin128
           file: ./abis/CurvePoolCoin128.json
+        - name: CurveLendingPool
+          file: ./abis/CurveLendingPool.json
         - name: MetaPool
           file: ./abis/MetaPool.json
         - name: CurvePoolV2
@@ -286,6 +292,8 @@ templates:
           file: ./abis/CurvePool.json
         - name: CurvePoolV2
           file: ./abis/CurvePoolV2.json
+        - name: CurveLendingPool
+          file: ./abis/CurveLendingPool.json
         - name: ERC20
           file: ./abis/ERC20.json
         - name: CToken
@@ -339,6 +347,8 @@ templates:
           file: ./abis/CurvePool.json
         - name: CurvePoolV2
           file: ./abis/CurvePoolV2.json
+        - name: CurveLendingPool
+          file: ./abis/CurveLendingPool.json
         - name: ERC20
           file: ./abis/ERC20.json
         - name: CToken


### PR DESCRIPTION
Store additional information in pool entities and snapshots:
- A parameter
- Offpeg fee / fee 
- Reserves (normalized to 18 decimals, including rate for C tokens)
- Whether pool uses a int128 or uint256 for coins array index